### PR TITLE
chore: replace custom Dockerfile with javascript-node:22 image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+	"name": "churchtools-organigram",
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:22",
+	"forwardPorts": [5173],
+	"portsAttributes": {
+		"5173": {
+			"label": "Vite Dev Server",
+			"onAutoForward": "openPreview"
+		}
+	}
+}

--- a/.ona/automations.yaml
+++ b/.ona/automations.yaml
@@ -1,0 +1,18 @@
+tasks:
+  installDeps:
+    name: Install dependencies
+    description: Install Bun and project dependencies.
+    command: |
+      curl -fsSL https://bun.sh/install | bash
+      sudo ln -sf "$HOME/.bun/bin/bun" /usr/local/bin/bun
+      bun install
+    triggeredBy:
+      - postDevcontainerStart
+
+services:
+  dev-server:
+    name: Dev Server
+    description: Vite development server.
+    commands:
+      start: bun run dev --host
+      ready: curl -f http://localhost:5173

--- a/.ona/automations.yaml
+++ b/.ona/automations.yaml
@@ -1,18 +1,18 @@
 tasks:
-  installDeps:
-    name: Install dependencies
-    description: Install Bun and project dependencies.
-    command: |
-      curl -fsSL https://bun.sh/install | bash
-      sudo ln -sf "$HOME/.bun/bin/bun" /usr/local/bin/bun
-      bun install
-    triggeredBy:
-      - postDevcontainerStart
+    installDeps:
+        name: Install dependencies
+        description: Install Bun and project dependencies.
+        command: |
+            curl -fsSL https://bun.sh/install | bash
+            sudo ln -sf "$HOME/.bun/bin/bun" /usr/local/bin/bun
+            bun install
+        triggeredBy:
+            - postDevcontainerStart
 
 services:
-  dev-server:
-    name: Dev Server
-    description: Vite development server.
-    commands:
-      start: bun run dev --host
-      ready: curl -f http://localhost:5173
+    dev-server:
+        name: Dev Server
+        description: Vite development server.
+        commands:
+            start: bun run dev --host
+            ready: curl -f http://localhost:5173


### PR DESCRIPTION
Replaces the generic `base:ubuntu-24.04` + empty Dockerfile setup with the purpose-built `javascript-node:22` image, which includes Node, npm, nvm, and common dev tools out of the box.

**Changes:**
- Remove `.devcontainer/Dockerfile` (no longer needed)
- Switch `devcontainer.json` to use `javascript-node:22` directly
- Add `.ona/automations.yaml` with `installDeps` task (installs Bun + dependencies) and `dev-server` service

**Note:** The `ghcr.io/devcontainers/features/bun` feature is unavailable in this environment (anonymous token requests to ghcr.io are denied). Bun is installed via `curl` in the `installDeps` task and symlinked to `/usr/local/bin/bun` for system-wide availability.